### PR TITLE
Make serviceName an Option[String] in QueryRequest

### DIFF
--- a/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
+++ b/zipkin-cassandra/src/main/scala/com/twitter/zipkin/storage/cassandra/CassandraSpanStore.scala
@@ -286,7 +286,7 @@ abstract class CassandraSpanStore(
       case (Some(x: String), Some(y: String)) =>
         repository.getTraceIdsBySpanName(x, y, endTs * 1000, lookback * 1000, limit)
       case (Some(x: String), None) => repository.getTraceIdsByServiceName(x, endTs * 1000, lookback * 1000, limit)
-      case (None, y) => repository.getAllTraceIds(endTs * 1000, lookback * 1000, limit)
+      case (None, _) => repository.getAllTraceIds(endTs * 1000, lookback * 1000, limit)
     })
 
     traceIdsFuture.map { traceIds =>

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/CollectAnnotationQueries.scala
@@ -19,7 +19,7 @@ trait CollectAnnotationQueries {
    * Only return maximum of limit trace ids from before the endTs.
    */
   protected def getTraceIdsByName(
-    serviceName: String,
+    serviceName: Option[String],
     spanName: Option[String],
     endTs: Long,
     lookback: Long,
@@ -32,7 +32,7 @@ trait CollectAnnotationQueries {
    * Only return maximum of limit trace ids from before the endTs.
    */
   protected def getTraceIdsByAnnotation(
-    serviceName: String,
+    serviceName: Option[String],
     annotation: String,
     value: Option[ByteBuffer],
     endTs: Long,
@@ -42,7 +42,7 @@ trait CollectAnnotationQueries {
 
   /** Only return traces where [[Span.duration]] is between minDuration and maxDuration */
   protected def getTraceIdsByDuration(
-    serviceName: String,
+    serviceName: Option[String],
     spanName: Option[String],
     minDuration: Long,
     maxDuration: Option[Long],

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -34,7 +34,7 @@ import scala.util.hashing.MurmurHash3
  * @param limit maximum number of traces to return. Defaults to 10.
  */
 // This is not a case-class as we need to enforce serviceName and spanName as lowercase
-class QueryRequest(_serviceName: String,
+class QueryRequest(_serviceName: Option[String] = None,
                    _spanName: Option[String] = None,
                    val annotations: Set[String] = Set.empty,
                    val binaryAnnotations: Set[(String, String)] = Set.empty,
@@ -45,7 +45,7 @@ class QueryRequest(_serviceName: String,
                    val limit: Int = 10) {
 
   /** Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]] */
-  val serviceName: String = _serviceName.toLowerCase
+  val serviceName: Option[String] = _serviceName.map(_.toLowerCase)
 
   /** When present, only include traces with this [[com.twitter.zipkin.common.Span.name]] */
   val spanName: Option[String] = _spanName.map(_.toLowerCase)
@@ -56,7 +56,7 @@ class QueryRequest(_serviceName: String,
    */
   val lookback: Long = Math.min(_lookback.getOrElse(endTs), endTs)
 
-  checkArgument(serviceName.nonEmpty, "serviceName was empty")
+  checkArgument(serviceName.map(_.nonEmpty).getOrElse(true), "serviceName was empty")
   checkArgument(spanName.map(_.nonEmpty).getOrElse(true), "spanName was empty")
   checkArgument(minDuration.map(_ > 0).getOrElse(true),
     () => "minDuration should be positive: was " + minDuration.get)
@@ -80,7 +80,7 @@ class QueryRequest(_serviceName: String,
   }
 
   def copy(
-    serviceName: String = this.serviceName,
+    serviceName: Option[String] = this.serviceName,
     spanName: Option[String] = this.spanName,
     annotations: Set[String] = this.annotations,
     binaryAnnotations: Set[(String, String)] = this.binaryAnnotations,
@@ -94,7 +94,7 @@ class QueryRequest(_serviceName: String,
 
 object QueryRequest {
   def apply(
-    serviceName: String,
+    serviceName: Option[String] = None,
     spanName: Option[String] = None,
     annotations: Set[String] = Set.empty,
     binaryAnnotations: Set[(String, String)] = Set.empty,

--- a/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
+++ b/zipkin-common/src/main/scala/com/twitter/zipkin/storage/QueryRequest.scala
@@ -15,8 +15,8 @@ import scala.util.hashing.MurmurHash3
  * the grain of [[com.twitter.zipkin.common.Span.timestamp]]. Milliseconds is a more familiar and
  * supported granularity for query, index and windowing functions.
  *
- * @param _serviceName Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]] and constrains
- *                     all other parameters.
+ * @param _serviceName When present, only include traces with this [[com.twitter.zipkin.common.Endpoint.serviceName]]
+ *                     and constrains all other parameters.
  * @param _spanName When present, only include traces with this [[com.twitter.zipkin.common.Span.name]]
  * @param annotations Include traces whose [[com.twitter.zipkin.common.Span.annotations]] include a value in this set.
  *                    This is an AND condition against the set, as well against [[binaryAnnotations]]
@@ -44,7 +44,7 @@ class QueryRequest(_serviceName: Option[String] = None,
                    _lookback: Option[Long] = None,
                    val limit: Int = 10) {
 
-  /** Mandatory [[com.twitter.zipkin.common.Endpoint.serviceName]] */
+  /** When present, only include traces with this [[com.twitter.zipkin.common.Endpoint.serviceName]] */
   val serviceName: Option[String] = _serviceName.map(_.toLowerCase)
 
   /** When present, only include traces with this [[com.twitter.zipkin.common.Span.name]] */

--- a/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
+++ b/zipkin-common/src/test/java/com/twitter/zipkin/storage/SpanStoreInJava.java
@@ -1,11 +1,11 @@
 package com.twitter.zipkin.storage;
 
+import com.twitter.util.Future;
+import com.twitter.zipkin.common.Span;
+import scala.Option;
 import scala.collection.Seq;
 import scala.collection.immutable.List;
 import scala.runtime.BoxedUnit;
-
-import com.twitter.util.Future;
-import com.twitter.zipkin.common.Span;
 
 /**
  * Shows that {@link SpanStore} is implementable in Java 7+.
@@ -33,7 +33,7 @@ public class SpanStoreInJava extends SpanStore {
     }
 
     @Override
-    public Future<Seq<String>> getSpanNames(String service) {
+    public Future<Seq<String>> getSpanNames(Option<String> service) {
         return null;
     }
 

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/common/QueryRequestTest.scala
@@ -7,49 +7,49 @@ class QueryRequestTest extends FunSuite {
 
   test("serviceName can't be empty") {
     intercept[IllegalArgumentException] {
-      QueryRequest("")
+      QueryRequest(Some(""))
     }
   }
 
   test("spanName can't be empty") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", Some(""))
+      QueryRequest(Some("foo"), Some(""))
     }
   }
 
   test("minDuration must be positive") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", minDuration = Some(0))
+      QueryRequest(Some("foo"), minDuration = Some(0))
     }
   }
 
   test("minDuration is required when specifying maxDuration") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", maxDuration = Some(34))
+      QueryRequest(Some("foo"), maxDuration = Some(34))
     }
   }
 
   test("maxDuration must be positive") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", minDuration = Some(1), maxDuration = Some(0))
+      QueryRequest(Some("foo"), minDuration = Some(1), maxDuration = Some(0))
     }
   }
 
   test("endTs must be positive") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", endTs = 0)
+      QueryRequest(Some("foo"), endTs = 0)
     }
   }
 
   test("lookback must be positive") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", lookback = Some(0))
+      QueryRequest(Some("foo"), lookback = Some(0))
     }
   }
 
   test("limit must be positive") {
     intercept[IllegalArgumentException] {
-      QueryRequest("foo", limit = 0)
+      QueryRequest(Some("foo"), limit = 0)
     }
   }
 }

--- a/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
+++ b/zipkin-common/src/test/scala/com/twitter/zipkin/storage/SpanStoreSpec.scala
@@ -97,7 +97,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     result(store(Seq(span1.copy(name = "yak"), span3)))
 
     // should be in order
-    result(store.getSpanNames("service")) should be(List("methodcall", "yak"))
+    result(store.getSpanNames(Some("service"))) should be(List("methodcall", "yak"))
   }
 
   @Test def getAllServiceNames() {
@@ -111,10 +111,11 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
    * This would only happen when the storage layer is bootstrapping, or has been purged.
    */
   @Test def allShouldWorkWhenEmpty() {
-    result(store.getTraces(QueryRequest("service"))) should be(empty)
-    result(store.getTraces(QueryRequest("service", Some("methodcall")))) should be(empty)
-    result(store.getTraces(QueryRequest("service", annotations = Set("custom")))) should be(empty)
-    result(store.getTraces(QueryRequest("service", binaryAnnotations = Set(("BAH", "BEH"))))) should be(
+    result(store.getTraces(QueryRequest())) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), Some("methodcall")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), annotations = Set("custom")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), binaryAnnotations = Set(("BAH", "BEH"))))) should be(
       empty
     )
   }
@@ -125,10 +126,11 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   @Test def allShouldWorkWhenNoAnnotationsYet() {
     result(store(Seq(spanEmptyServiceName)))
 
-    result(store.getTraces(QueryRequest("service"))) should be(empty)
-    result(store.getTraces(QueryRequest("service", Some("methodcall")))) should be(empty)
-    result(store.getTraces(QueryRequest("service", annotations = Set("custom")))) should be(empty)
-    result(store.getTraces(QueryRequest("service", binaryAnnotations = Set(("BAH", "BEH"))))) should be(
+    result(store.getTraces(QueryRequest())) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), Some("methodcall")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), annotations = Set("custom")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), binaryAnnotations = Set(("BAH", "BEH"))))) should be(
       empty
     )
   }
@@ -136,15 +138,18 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   @Test def getTraces_spanName() {
     result(store(Seq(span1)))
 
-    result(store.getTraces(QueryRequest("service"))) should be(
+    result(store.getTraces(QueryRequest())) should be(Seq(Seq(span1)))
+    result(store.getTraces(QueryRequest(None, Some("methodcall")))) should be(Seq(Seq(span1)))
+
+    result(store.getTraces(QueryRequest(Some("service")))) should be(
       Seq(Seq(span1))
     )
-    result(store.getTraces(QueryRequest("service", Some("methodcall")))) should be(
+    result(store.getTraces(QueryRequest(Some("service"), Some("methodcall")))) should be(
       Seq(Seq(span1))
     )
-    result(store.getTraces(QueryRequest("badservice"))) should be(empty)
-    result(store.getTraces(QueryRequest("service", Some("badmethod")))) should be(empty)
-    result(store.getTraces(QueryRequest("badservice", Some("badmethod")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("badservice")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), Some("badmethod")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("badservice"), Some("badmethod")))) should be(empty)
   }
 
   @Test def getTraces_serviceNameInBinaryAnnotation() {
@@ -153,7 +158,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     result(store(localTrace))
 
-    result(store.getTraces(QueryRequest("service"))) should be(Seq(localTrace))
+    result(store.getTraces(QueryRequest(Some("service")))) should be(Seq(localTrace))
   }
 
   /** Shows that duration queries go against the root span, not the child */
@@ -181,28 +186,32 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     val lookback = 12L * 60 * 60 * 1000 // 12hrs, instead of 7days
     val endTs = today + 1 // greater than all timestamps above
-    val q = QueryRequest("placeholder", lookback = Some(lookback), endTs = endTs)
+    val q = QueryRequest(Some("placeholder"), lookback = Some(lookback), endTs = endTs)
 
     // Min duration is inclusive and is applied by service.
-    result(store.getTraces(q.copy(serviceName = "service1", minDuration = targz.duration))) should be(
+    result(store.getTraces(q.copy(serviceName = Some("service1"), minDuration = targz.duration))) should be(
       Seq(trace1)
     )
-    result(store.getTraces(q.copy(serviceName = "service3", minDuration = targz.duration))) should be(
+    result(store.getTraces(q.copy(serviceName = Some("service3"), minDuration = targz.duration))) should be(
       Seq(trace2)
     )
 
+    result(store.getTraces(q.copy(serviceName = None, minDuration = targz.duration))) should be(
+      Seq(trace2, trace1)
+    )
+
     // Duration bounds aren't limited to root spans: they apply to all spans by service in a trace
-    result(store.getTraces(q.copy(serviceName = "service2", minDuration = zip.duration, maxDuration = tar.duration))) should be(
+    result(store.getTraces(q.copy(serviceName = Some("service2"), minDuration = zip.duration, maxDuration = tar.duration))) should be(
       Seq(trace3, trace2, trace1) // service2 is in the middle of trace1 and 2, but root of trace3
     )
 
     // Span name should apply to the duration filter
-    result(store.getTraces(q.copy(serviceName = "service2", spanName = Some("zip"), minDuration = zip.duration))) should be(
+    result(store.getTraces(q.copy(serviceName = Some("service2"), spanName = Some("zip"), minDuration = zip.duration))) should be(
       Seq(trace3)
     )
 
     // Max duration should filter our longer spans from the same service
-    result(store.getTraces(q.copy(serviceName = "service2", minDuration = gz.duration, maxDuration = zip.duration))) should be(
+    result(store.getTraces(q.copy(serviceName = Some("service2"), minDuration = gz.duration, maxDuration = zip.duration))) should be(
       Seq(trace3)
     )
   }
@@ -216,16 +225,17 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     // store the binary annotations
     result(store(Seq(span1.copy(timestamp = None, duration = None, annotations = List.empty))))
 
-    result(store.getTraces(QueryRequest("service"))) should be(empty)
-    result(store.getTraces(QueryRequest("service", Some("methodcall")))) should be(empty)
+    result(store.getTraces(QueryRequest())) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service")))) should be(empty)
+    result(store.getTraces(QueryRequest(Some("service"), Some("methodcall")))) should be(empty)
 
     // now store the timestamped annotations
     result(store(Seq(span1.copy(binaryAnnotations = Seq.empty))))
 
-    result(store.getTraces(QueryRequest("service"))) should be(
+    result(store.getTraces(QueryRequest(Some("service")))) should be(
       Seq(Seq(span1))
     )
-    result(store.getTraces(QueryRequest("service", Some("methodcall")))) should be(
+    result(store.getTraces(QueryRequest(Some("service"), Some("methodcall")))) should be(
       Seq(Seq(span1))
     )
   }
@@ -234,12 +244,12 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     result(store(Seq(span1)))
 
     // fetch by time based annotation, find trace
-    result(store.getTraces(QueryRequest("service", annotations = Set("custom")))) should be(
+    result(store.getTraces(QueryRequest(None, annotations = Set("custom")))) should be(
       Seq(Seq(span1))
     )
 
     // should find traces by the key and value annotation
-    result(store.getTraces(QueryRequest("service", binaryAnnotations = Set(("BAH", "BEH"))))) should be(
+    result(store.getTraces(QueryRequest(None, binaryAnnotations = Set(("BAH", "BEH"))))) should be(
       Seq(Seq(span1))
     )
   }
@@ -253,15 +263,15 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     result(store(Seq(foo, barAndFoo, fooAndBazAndQux, barAndFooAndBazAndQux)))
 
-    result(store.getTraces(QueryRequest("service", annotations = Set("foo")))) should be(
+    result(store.getTraces(QueryRequest(Some("service"), annotations = Set("foo")))) should be(
       Seq(List(barAndFooAndBazAndQux), List(fooAndBazAndQux), List(barAndFoo), List(foo))
     )
 
-    result(store.getTraces(QueryRequest("service", annotations = Set("foo", "bar")))) should be(
+    result(store.getTraces(QueryRequest(Some("service"), annotations = Set("foo", "bar")))) should be(
       Seq(List(barAndFooAndBazAndQux), List(barAndFoo))
     )
 
-    result(store.getTraces(QueryRequest("service", annotations = Set("foo", "bar"), binaryAnnotations = Set(("baz", "qux"))))) should be(
+    result(store.getTraces(QueryRequest(Some("service"), annotations = Set("foo", "bar"), binaryAnnotations = Set(("baz", "qux"))))) should be(
       Seq(List(barAndFooAndBazAndQux))
     )
   }
@@ -273,7 +283,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     result(store(Seq(span)))
 
-    result(store.getTraces(QueryRequest("service"))) should be(
+    result(store.getTraces(QueryRequest())) should be(
       Seq(List(span))
     )
     result(store.getTracesByIds(List(1L))) should be(
@@ -304,33 +314,33 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
     val merged = client.copy(
       annotations = (client.annotations ::: server.annotations).sorted)
 
-    result(store.getTraces(QueryRequest("service1"))) should be(Seq(List(merged)))
+    result(store.getTraces(QueryRequest(Some("service1")))) should be(Seq(List(merged)))
   }
 
   /** limit should apply to traces closest to endTs */
   @Test def getTraces_limit() {
     result(store(Seq(span1, span3))) // span1's timestamp is 1000, span3's timestamp is 2000
 
-    result(store.getTraces(QueryRequest("service", limit = 1))) should be(Seq(List(span3)))
+    result(store.getTraces(QueryRequest(Some("service"), limit = 1))) should be(Seq(List(span3)))
   }
 
   /** Traces whose root span has timestamps before or at endTs are returned */
   @Test def getTraces_endTsAndLookback() {
     result(store(Seq(span1, span3))) // span1's timestamp is 1000, span3's timestamp is 2000
 
-    result(store.getTraces(QueryRequest("service", endTs = today + 1))) should be(Seq(List(span1)))
-    result(store.getTraces(QueryRequest("service", endTs = today + 2))) should be(Seq(List(span3), List(span1)))
-    result(store.getTraces(QueryRequest("service", endTs = today + 3))) should be(Seq(List(span3), List(span1)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 1))) should be(Seq(List(span1)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 2))) should be(Seq(List(span3), List(span1)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 3))) should be(Seq(List(span3), List(span1)))
   }
 
   /** Traces whose root span has timestamps between (endTs - lookback) and endTs are returned */
   @Test def getTraces_lookback() {
     result(store(Seq(span1, span3))) // span1's timestamp is 1000, span3's timestamp is 2000
 
-    result(store.getTraces(QueryRequest("service", endTs = today + 1, lookback = Some(1)))) should be(Seq(List(span1)))
-    result(store.getTraces(QueryRequest("service", endTs = today + 2, lookback = Some(1)))) should be(Seq(List(span3), List(span1)))
-    result(store.getTraces(QueryRequest("service", endTs = today + 3, lookback = Some(1)))) should be(Seq(List(span3)))
-    result(store.getTraces(QueryRequest("service", endTs = today + 3, lookback = Some(2)))) should be(Seq(List(span3), List(span1)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 1, lookback = Some(1)))) should be(Seq(List(span1)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 2, lookback = Some(1)))) should be(Seq(List(span3), List(span1)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 3, lookback = Some(1)))) should be(Seq(List(span3)))
+    result(store.getTraces(QueryRequest(Some("service"), endTs = today + 3, lookback = Some(2)))) should be(Seq(List(span3), List(span1)))
   }
 
   @Test def getAllServiceNames_emptyServiceName() {
@@ -342,13 +352,13 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   @Test def getSpanNames_emptySpanName() {
     result(store(Seq(spanEmptySpanName)))
 
-    result(store.getSpanNames(spanEmptySpanName.name)) should be(empty)
+    result(store.getSpanNames(Some(spanEmptySpanName.name))) should be(empty)
   }
 
   @Test def spanNamesGoLowercase() {
     result(store(Seq(span1)))
 
-    result(store.getTraces(QueryRequest("service", Some("MeThOdCaLl")))) should be(
+    result(store.getTraces(QueryRequest(Some("service"), Some("MeThOdCaLl")))) should be(
       Seq(Seq(span1))
     )
   }
@@ -356,9 +366,9 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
   @Test def serviceNamesGoLowercase() {
     result(store(Seq(span1)))
 
-    result(store.getSpanNames("SeRvIcE")) should be(List("methodcall"))
+    result(store.getSpanNames(Some("SeRvIcE"))) should be(List("methodcall"))
 
-    result(store.getTraces(QueryRequest("SeRvIcE"))) should be(
+    result(store.getTraces(QueryRequest(Some("SeRvIcE")))) should be(
       Seq(Seq(span1))
     )
   }
@@ -408,7 +418,7 @@ abstract class SpanStoreSpec extends JUnitSuite with Matchers {
 
     // Regardless of when clock skew is corrected, it should be corrected before traces return
     result(store(List(parent, remoteChild, localChild)))
-    val adjusted = result(store.getTraces(QueryRequest("frontend")))(0)
+    val adjusted = result(store.getTraces(QueryRequest(Some("frontend"))))(0)
 
     // After correction, children happen after their parent
     adjusted(0).timestamp.get should be <= adjusted(1).timestamp.get

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/QueryExtractor.scala
@@ -31,7 +31,7 @@ class QueryExtractor @Inject()(@Flag("zipkin.queryService.limit") val defaultLim
    * on the GET parameters present
    */
   def apply(req: Request): Try[QueryRequest] = Try {
-    val serviceName = req.params.get("serviceName").getOrElse("")
+    val serviceName = req.params.get("serviceName")
     val spanName = req.params.get("spanName").flatMap(n => if (n == "all" || n == "") None else Some(n))
     val minDuration = req.params.get("minDuration").flatMap(d => if (d.isEmpty) None else Some(d.toLong))
     val maxDuration = req.params.get("maxDuration").flatMap(d => if (d.isEmpty) None else Some(d.toLong))

--- a/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
+++ b/zipkin-query/src/main/scala/com/twitter/zipkin/query/ZipkinQueryController.scala
@@ -147,6 +147,6 @@ class ZipkinQueryController @Inject()(spanStore: SpanStore,
   }
 }
 
-case class GetSpanNamesRequest(@QueryParam serviceName: String)
+case class GetSpanNamesRequest(@QueryParam serviceName: Option[String])
 
 case class GetDependenciesRequest(@QueryParam endTs: Long, @QueryParam lookback: Option[Long])


### PR DESCRIPTION
issue: zipkin query currently has no way to request traces across services, making it difficult to show any sort of inter-service overview ui.

proposed solution: change serviceName from being required to being optional

places I'm looking for feedback: cassandra span store & repository
